### PR TITLE
Replace &dyn Fn with impl Fn to make futures Sync

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -55,7 +55,7 @@ impl ArpClient {
         timeout: Option<Duration>,
         message: ArpMessage,
     ) -> Result<ArpMessage, Error> {
-        self.send_message_with_check(timeout, message, &|arp_message| Some(arp_message))
+        self.send_message_with_check(timeout, message, |arp_message| Some(arp_message))
             .await
     }
 
@@ -67,7 +67,7 @@ impl ArpClient {
         &mut self,
         timeout: Option<Duration>,
         message: ArpMessage,
-        check_answer: &dyn Fn(ArpMessage) -> Option<T>,
+        check_answer: impl Fn(ArpMessage) -> Option<T>,
     ) -> Result<T, Error> {
         let unpacked_timeout = match timeout {
             Some(t) => t,
@@ -108,7 +108,7 @@ impl ArpClient {
             ip_addr,
         );
 
-        self.send_message_with_check(timeout, message, &|arp_message| {
+        self.send_message_with_check(timeout, message, |arp_message| {
             return if arp_message.source_protocol_address == ip_addr {
                 Some(arp_message.source_hardware_address.into())
             } else {
@@ -129,7 +129,7 @@ impl ArpClient {
         let message =
             ArpMessage::new_rarp_request(self.interface.get_mac().into(), mac_addr.into());
 
-        self.send_message_with_check(timeout, message, &|arp_message| {
+        self.send_message_with_check(timeout, message, |arp_message| {
             let source_mac: MacAddr = arp_message.source_hardware_address.into();
             if source_mac == mac_addr {
                 Some(arp_message.target_protocol_address)


### PR DESCRIPTION
Anything that uses ArpClient::send_message_with_check (e.g. ip_to_mac) is not a Send future. This makes using it in e.g. tokio::spawn not possible:

```rust
tokio::spawn(async move {
    // ...
    let mut client = ArpClient::new();
    let mac = client.ip_to_mac(ip, Some(Duration::from_secs(5))).await.unwrap();
    // ...
})
```

```
error: generator cannot be sent between threads safely
   --> src/scan.rs:57:13
    |
57  |             tokio::spawn(async move {
    |             ^^^^^^^^^^^^ future created by async block is not `Send`
    |
    = help: the trait `Sync` is not implemented for `dyn Fn(ArpMessage) -> std::option::Option<MacAddr>`
note: required by a bound in `tokio::spawn`
   --> /home/saiko/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.17.0/src/task/spawn.rs:127:21
    |
127 |         T: Future + Send + 'static,
    |                     ^^^^ required by this bound in `tokio::spawn`
```

This replaces the `&dyn Fn` with `impl Fn` to fix this.